### PR TITLE
Add ThingSet via CAN ISO-TP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/isotp"]
+	path = lib/isotp
+	url = https://github.com/LibreSolar/isotp-c

--- a/README.md
+++ b/README.md
@@ -40,12 +40,23 @@ The data can be accessed in the same way as described above.
 - Data access via HTTP JSON API
 - Publishing of monitoring data via WiFi to
     - Open Energy Monitor [Emoncms](https://emoncms.org/)
-    - MQTT sever (ToDo)
+    - MQTT server (ToDo)
 - Data logging on SD card (ToDo)
 
 ## Usage
 
-### Build the Webapp
+### Getting the firmware
+
+This firmware repository contains git submodules, so you need to clone (download) it by calling:
+
+```
+git clone --recursive https://github.com/LibreSolar/esp32-edge-firmware
+```
+
+Unfortunately, the green GitHub "Clone or download" button does not include submodules. If you cloned the repository already and want to pull the submodules, run `git submodule update --init --recursive`.
+
+
+### Building the webapp
 
 To be able to build the esp32-edge-firmware you need to build the webapp first.
 To do so, go into the webapp folder
@@ -59,7 +70,8 @@ and run
     npm install
     npm run build
 ```
-you are now able to build the firmware itself.
+
+You are now able to build the firmware itself.
 
 ### ESP-IDF toolchain
 
@@ -72,7 +84,7 @@ After installation run the following commands:
 
 ### PlatformIO
 
-You can use PlatformIO for easy bulding and flashing. Currently, ESP-IDF 4.0 support is still in beta phase, so it might not work out of the box. However, the setup in `platformio.ini` was adjusted to support the new ESP-IDF already.
+You can use PlatformIO for easy building and flashing. However, the PlatformIO packages for ESP-IDF are not updated as frequently as the official repositories.
 
 ### Configuration
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -10,6 +10,8 @@ set(app_sources
 	"web_fs.c"
 	"web_server.c"
 	"provisioning.c"
+	"../lib/isotp/isotp.c"
+	"isotp_user.c"
 )
 
 idf_component_register(SRCS ${app_sources} INCLUDE_DIRS ".")

--- a/main/can.h
+++ b/main/can.h
@@ -35,6 +35,11 @@ void can_setup();
 void can_receive_task(void *arg);
 
 /**
+ * Thread performing regular requests to other devices using ISO-TP
+ */
+void isotp_task(void *arg);
+
+/**
  * Get data from MPPT connected via CAN bus and convert it to JSON
  *
  * Caution: This function is currently not thread-safe and could be changed while reading it.

--- a/main/isotp_user.c
+++ b/main/isotp_user.c
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2020 Martin Jäger / Libre Solar
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_system.h"
+#include "esp_err.h"
+#include "esp_log.h"
+
+#include "driver/can.h"
+#include "driver/gpio.h"
+
+#include "../lib/isotp/isotp.h"
+
+/*
+ * required, this must send a single CAN message with the given arbitration
+ * ID (i.e. the CAN message ID) and data. The size will never be more than 8
+ * bytes.
+ */
+int isotp_user_send_can(const uint32_t arbitration_id,
+                        const uint8_t* data, const uint8_t size)
+{
+    can_message_t msg;
+    memcpy(msg.data, data, size);
+    msg.data_length_code = size;
+    msg.identifier = arbitration_id;
+    msg.flags = CAN_MSG_FLAG_EXTD;
+    return can_transmit(&msg, 0);
+}
+
+/*
+ * required, return system tick, unit is millisecond
+ */
+uint32_t isotp_user_get_ms(void)
+{
+    return esp_timer_get_time() / 1000;
+}
+
+/*
+ * optional, provide to receive debugging log messages
+ */
+void isotp_user_debug(const char* message, ...)
+{
+	va_list argp;
+	va_start(argp, message);
+	printf(message, argp);
+	va_end(argp);
+}

--- a/main/main.c
+++ b/main/main.c
@@ -60,6 +60,8 @@ void app_main(void)
     can_setup();
     xTaskCreatePinnedToCore(can_receive_task, "CAN_rx", 4096,
         NULL, RX_TASK_PRIO, NULL, 1);
+    xTaskCreatePinnedToCore(isotp_task, "CAN_isotp", 1024,
+        NULL, RX_TASK_PRIO, NULL, 1);
 #endif
 
 #if CONFIG_THINGSET_SERIAL


### PR DESCRIPTION
This PR adds initial support for ThingSet requests via CAN using [lishen2/isotp-c library](https://github.com/lishen2/isotp-c) (forked to Libre Solar github account.

Firmware has been tested with Linux can-utils and MPPT 2420 HC charge controller using Zephyr implementation. The Zephyr implementation needs [these additional features](https://github.com/zephyrproject-rtos/zephyr/pull/31078) to support messages with padding.

As ISO-TP standard suggests fixed bytes (0xDA) for the bits 16..23, the ThingSet message format had to be changed such that the function code (first byte of a request) is included in the data and not in the ID. The ThingSet spec has to be updated accordingly.

Open points for proper implementation:

- Integrate with existing URI handler instead of sending regular requests
- Device discovery on the CAN bus instead of using single hard-coded target address for MPPT
- Automatic CAN address assignment (ThingSet approach still to be specified)