### PR TITLE
Fixes ota firmware upgrade for STM32G431

### DIFF
--- a/main/stm32bl.c
+++ b/main/stm32bl.c
@@ -35,6 +35,22 @@ static const uint8_t stm_reset_code[] = {
     0x04, 0x00, 0xfa, 0x05	// .word 0x05fa0004 <AIRCR_RESET_VALUE> = VECTKEY | SYSRESETREQ
 };
 
+static const stm32_device_t devices[] = {
+    // STM32G431XX
+    {0x468, 0x20004000, 0x08000000, 0x1FFF7800},
+    // STM32L07XX
+    {0x447, 0x20002000, 0x08000000, 0x1FF80000}
+};
+
+static const stm32_device_t *get_device_by_id(uint16_t id)
+{
+    for (int i = 0; i < sizeof(devices); i++) {
+        if (devices[i].id == id) {
+            return &(devices[i]);
+        }
+    }
+    return NULL;
+}
 
 static uint8_t calc_checksum(uint8_t *data, uint8_t len)
 {
@@ -52,11 +68,6 @@ static void send_buf(uint8_t *buf, size_t len)
     uart_write_bytes(uart, (char *)&checksum, 1);
 }
 
-static inline void send_byte(uint8_t byte)
-{
-    send_buf(&byte, 1);
-}
-
 static inline void send_cmd(uint8_t cmd)
 {
     uint8_t buf[] = { cmd, ~cmd };
@@ -69,7 +80,7 @@ static void send_address(uint32_t addr)
         ESP_LOGE(TAG, "Error: address must be 4 byte aligned");
         return;
     }
-    uint8_t buf[] = { addr >> 24, (addr >> 16) & 0xFF, (addr >> 8) & 0XFF, addr & 0xFF };
+    uint8_t buf[] = { addr >> 24, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF };
     send_buf(buf, sizeof(buf));
 }
 
@@ -88,7 +99,7 @@ int stm32bl_erase_all(uint16_t max_pages)
     uint8_t buf[4] = {};
     buf[0] = 0;
     buf[1] = 0;
-    for(int i = 0; i < max_pages; i++) {
+    for (int i = 0; i < max_pages; i++) {
         send_cmd(STM32BL_EEM);
         if (wait_resp() != STM32BL_ACK) {
             ESP_LOGE(TAG, "Erasing request failed");
@@ -102,15 +113,19 @@ int stm32bl_erase_all(uint16_t max_pages)
             return ESP_FAIL;
         }
     }
-    return STM32BL_ACK;
+
+    ESP_LOGD(TAG, "Erasing successfully finished");
+    return ESP_OK;
 }
 
 int stm32bl_go(uint32_t addr)
 {
     send_cmd(STM32BL_GO);
     if (wait_resp() != STM32BL_ACK) {
+        ESP_LOGE(TAG,"Go command rejected");
         return ESP_FAIL;
     }
+
     send_address(addr);
     return wait_resp();
 }
@@ -118,12 +133,12 @@ int stm32bl_go(uint32_t addr)
 static int stm32bl_run_raw_code(uint32_t target_address, const uint8_t *code, uint32_t code_size)
 {
     uint32_t stack_addr = STM32_RAM_START_ADDR;
-    uint32_t code_address= target_address + 8 + 1;
+    uint32_t code_address = target_address + 8 + 1;
     uint32_t length = code_size + 8;
     uint8_t *mem;
 
     if (target_address % 4 != 0) {
-        ESP_LOGE(TAG, "Error: code address must be 4 byte aligned");
+        ESP_LOGE(TAG, "Code address must be 4 byte aligned");
         return ESP_FAIL;
     }
 
@@ -136,34 +151,84 @@ static int stm32bl_run_raw_code(uint32_t target_address, const uint8_t *code, ui
     memcpy(mem + 4, &code_address, sizeof(uint32_t));
     memcpy(mem + 8, code, code_size);
 
-    stm32bl_write(mem, length, target_address);
+    if (stm32bl_write(mem, length, target_address) != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Could not write raw code!");
+    }
 
     free(mem);
     return stm32bl_go(target_address);
 }
 
-int stm32bl_reset_device()
+int stm32bl_reset_device(uint16_t id)
 {
-    uint32_t address = 0x20002000;
-    return stm32bl_run_raw_code(address, stm_reset_code, sizeof(stm_reset_code));
+    const stm32_device_t *device = get_device_by_id(id);
+    if (device == NULL) {
+        ESP_LOGE(TAG, "Cannot reset unkown device");
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, "Found device: 0x%x", device->id);
+
+    int ret;
+    switch (device->id) {
+        case STM32L07XX_ID:
+            ret = stm32bl_run_raw_code(device->sram_start, stm_reset_code, sizeof(stm_reset_code));
+            break;
+        case STM32G431XX_ID:
+            ret = stm32bl_reset_optr(device->opt_start);
+            break;
+        default:
+            ESP_LOGE(TAG, "Can't reset unknown device!");
+            ret = ESP_FAIL;
+    }
+
+    // wait for reboot
+    vTaskDelay(pdMS_TO_TICKS(500));
+    if (ret == ESP_FAIL) {
+        ESP_LOGE(TAG, "Unable reset device!");
+        return ESP_FAIL;
+    };
+
+    return ESP_OK;
 }
 
+// Use with caution, showed incoherent behavior with different MCUs
 int stm32bl_unprotect_write()
 {
     send_cmd(STM32BL_WUP);
     if (wait_resp() != STM32BL_ACK) {
+        ESP_LOGE(TAG,"Unprotect write rejected");
         return ESP_FAIL;
     }
-    return wait_resp();
+    wait_resp();
+
+    // Unprotect write generates a reset, so we have to reinit the UART connection
+    vTaskDelay(pdMS_TO_TICKS(500));
+
+    if (stm32bl_init() != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Reinit failed");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
 }
 
+// Use with caution, showed incoherent behavior with different MCUs
 int stm32bl_unprotect_read()
 {
     send_cmd(STM32BL_RUP);
     if (wait_resp() != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Unprotect read rejected");
         return ESP_FAIL;
     }
-    return wait_resp();
+    wait_resp();
+
+    // Unprotect read generates a reset, so we have to reinit the UART connection
+    vTaskDelay(pdMS_TO_TICKS(500));
+
+    if (stm32bl_init() != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Reinit failed");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
 }
 
 int stm32bl_protect_read()
@@ -186,15 +251,24 @@ int stm32bl_read(uint8_t *buf, uint8_t num_bytes, uint32_t addr)
 {
     send_cmd(STM32BL_RM);
     if (wait_resp() != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Read command rejected");
         return ESP_FAIL;
     }
 
     send_address(addr);
-    if (wait_resp() == STM32BL_ACK) {
+    if (wait_resp() != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Read address rejected");
         return ESP_FAIL;
     }
 
-    send_byte(num_bytes);
+    // One byte with 0 < N < 256 and its complement is the same as
+    // sending a command
+    send_cmd(num_bytes);
+    if (wait_resp() != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Number of bytes to read rejected");
+        return ESP_FAIL;
+    }
+
     int ret = uart_read_bytes(uart, buf, num_bytes, pdMS_TO_TICKS(UART_TIMEOUT_MS));
     if (ret > 0) {
         return STM32BL_ACK;
@@ -209,14 +283,15 @@ int stm32bl_write(uint8_t *buf, uint32_t num_bytes, uint32_t start_addr)
         ESP_LOGE(TAG, "Data is not aligned");
         return ESP_FAIL;
     }
+
     send_cmd(STM32BL_WM);
-    if (wait_resp() != STM32BL_ACK) {
+    if (wait_resp() == STM32BL_NACK) {
         ESP_LOGE(TAG, "Write request failed");
         return ESP_FAIL;
     }
 
     send_address(start_addr);
-    if (wait_resp() != STM32BL_ACK) {
+    if (wait_resp() == STM32BL_NACK) {
         ESP_LOGE(TAG, "Start address rejected: 0x%.8x", start_addr);
         return ESP_FAIL;
     }
@@ -225,6 +300,7 @@ int stm32bl_write(uint8_t *buf, uint32_t num_bytes, uint32_t start_addr)
     total[0] = num_bytes - 1;
     xthal_memcpy(total + 1, buf, num_bytes);
 
+    ESP_LOGD(TAG, "Sending out %d bytes", num_bytes);
     send_buf(total, num_bytes + 1);
     free(total);
     return wait_resp();
@@ -236,6 +312,7 @@ int stm32bl_get_version()
 
     send_cmd(STM32BL_GET);
     if (wait_resp() != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Get command rejected");
         return ESP_FAIL;
     }
 
@@ -262,6 +339,42 @@ int stm32bl_get_id()
     }
 
     return ESP_FAIL;
+}
+
+int stm32bl_reset_optr(uint32_t ob_addr)
+{
+    uint32_t optr[12] = {};
+    ESP_LOGD(TAG, "Going to read from 0x%x", ob_addr);
+    int ret = stm32bl_read((uint8_t *) &optr, sizeof(optr), ob_addr);
+    if (ret != STM32BL_ACK) {
+        ESP_LOGE(TAG, "Unable to read option bytes");
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, "nSWBOOT: %d", (optr[0] & STM32_nSWBOOT0) >> 26);
+    ESP_LOGD(TAG, "nBOOT0: %d", (optr[0] & STM32_nBOOT0) >> 27);
+    ESP_LOGD(TAG, "nBOOT1: %d", (optr[0] & STM32_nBOOT1) >> 23);
+
+    // set software boot = 0, which disables the selection via pin
+    // should already be set anyway, just making sure here
+    optr[0] &= ~STM32_nSWBOOT0;
+    // set BOOT0 = 1 to boot to main flash memory
+    optr[0] |= STM32_nBOOT0;
+    // set BOOT1 = 1. If the above values are corrupted, this will make sure
+    // that the chip does not boot from SRAM but System Memory and could possibly
+    // be recovered
+    optr[0] |= STM32_nBOOT1;
+    // the "right" half of the double word is the negated left half
+    optr[1] = ~optr[0];
+
+    if (stm32bl_write((uint8_t *) &optr, sizeof(optr), ob_addr) != STM32BL_ACK) {
+        // this is bad, we can't reset the option bytes and are stuck in the bootloader
+        ESP_LOGE(TAG, "Could not write option bytes");
+        return ESP_FAIL;
+    }
+
+    // A system reset should be triggered now
+    return ESP_OK;
 }
 
 #endif //UNIT_TEST

--- a/main/stm32bl.h
+++ b/main/stm32bl.h
@@ -27,15 +27,28 @@
 #define STM32BL_RUP     0x92    /* Readout Unprotect command */
 
 /* STM32 code start address (must be changed if custom bootloader is used */
-#define STM32_FLASH_START_ADDR        0x08000000
-#define STM32_RAM_START_ADDR    0x20002000
+#define STM32_FLASH_START_ADDR      0x08000000
+#define STM32_RAM_START_ADDR        0x20002000
 
+#define STM32L07XX_ID           0x447
+#define STM32G431XX_ID          0x468
+
+#define STM32_nBOOT0            (1U << 27)
+#define STM32_nSWBOOT0          (1U << 26)
+#define STM32_nBOOT1            (1U << 23)
+
+typedef struct {
+    uint16_t id;
+    uint32_t sram_start;
+    uint32_t flash_start;
+    uint32_t opt_start;
+} stm32_device_t;
 /**
  * Resets the device after flashing
  *
  * @return ESP_FAIL in case of error
  */
-int stm32bl_reset_device();
+int stm32bl_reset_device(uint16_t id);
 
 /**
  * Get bootloader version
@@ -56,7 +69,8 @@ int stm32bl_get_id();
  *
  * @return
  *      - ESP_FAIL in case of communication error
- *      - STM32BL_ACK if erase was successful
+ *      - STM32BL_ACK if protection was successfully unset
+ *      - STM32BL_NACK if protection was not successfully unset
  */
 int stm32bl_unprotect_write();
 
@@ -65,7 +79,8 @@ int stm32bl_unprotect_write();
  *
  * @return
  *      - ESP_FAIL in case of communication error
- *      - STM32BL_ACK if erase was successful
+ *      - STM32BL_ACK if protection was successfully unset
+ *      - STM32BL_NACK if protection was not successfully unset
  */
 int stm32bl_unprotect_read();
 
@@ -74,7 +89,8 @@ int stm32bl_unprotect_read();
  *
  * @return
  *      - ESP_FAIL in case of communication error
- *      - STM32BL_ACK if erase was successful
+ *      - STM32BL_ACK if protection was successfully set
+ *      - STM32BL_NACK if protection was not successfully set
  */
 int stm32bl_protect_read();
 
@@ -112,14 +128,14 @@ int stm32bl_read(uint8_t *buf, uint8_t num_bytes, uint32_t start_addr);
  * @return
  *      - ESP_FAIL in case of communication error
  *      - STM32BL_ACK if reading was successful
- *      - STM32BL_NACK if reading was not successful
+ *      - STM32BL_NACK if writing was not successful
  */
 int stm32bl_write(uint8_t *buf, uint32_t num_bytes, uint32_t start_addr);
 
 /**
  * Go to address (to start program)
  *
- * @param addr Address in MCU RAM (typically 0x08000000)
+ * @param addr Address in MCU RAM
  *
  * @return
  *      - ESP_FAIL in case of communication error
@@ -137,5 +153,17 @@ int stm32bl_go(uint32_t addr);
  *      - STM32BL_NACK if reading was not successful
  */
 int stm32bl_init();
+
+/**
+ * Resets the option bytes so that the bootloader is not
+ * started over and over again.
+ *
+ * @param The starting address of the option byte area
+ * @return
+ *      - ESP_FAIL in case of communication error
+ *      - STM32BL_ACK if reading and writing was successful
+ *      - STM32BL_NACK if reading or writing was not successful
+ */
+int stm32bl_reset_optr(uint32_t ob_addr);
 
 #endif /* STM32BL_H_ */

--- a/main/ts_client.c
+++ b/main/ts_client.c
@@ -95,7 +95,9 @@ static int strlen_null(char *r)
 
 char *exec_or_create(char *node)
 {
-    if (strstr(node, "auth") != NULL || strstr(node, "exec") != NULL) {
+    if (strstr(node, "auth") != NULL ||
+        strstr(node, "exec") != NULL ||
+        strstr(node, "dfu") != NULL) {
         return "!";
     } else {
         return "+";


### PR DESCRIPTION
I added a reset method to change the option bytes and a struct to hold
information about the different MCUs used by LibreSolar. I restricted
the chunk that is written to the bootloader to 128bytes. In theory, it could
be 256bytes but that led to unclear errors. It only takes a few seconds longer
since overhead is small anyway. I also changed the way the ID is extracted from
the url because my 1210-HUS had an ID with length 2, which should not happen but
but now the code is more robust and the ID can be whatever length.